### PR TITLE
Update to latest NoFlo and added retry on failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "noflo-mandrill",
   "description": "Mandrill email API components for NoFlo",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "author": {
     "name": "Henri Bergius",
     "email": "henri.bergius@iki.fi"
@@ -17,7 +17,7 @@
     }
   ],
   "dependencies": {
-    "noflo": "~0.5.0",
+    "noflo": "~0.5.9",
     "mandrill-api": "~1.0.37"
   },
   "devDependencies": {


### PR DESCRIPTION
- Using 0.5 Ports API and WirePattern.
- Optional `retries` port specifies how many times a component will
  try to send a message again with 1 second interval on error.
